### PR TITLE
Allow block-size < 1M

### DIFF
--- a/DBsplit.c
+++ b/DBsplit.c
@@ -80,6 +80,7 @@ int main(int argc, char *argv[])
   int        ALL;
   int        CUTOFF;
   int        SIZE;
+  int        SIZE_UNIT_LG;
 
   { int   i, j, k;
     int   flags[128];
@@ -89,6 +90,7 @@ int main(int argc, char *argv[])
 
     CUTOFF = 0;
     SIZE   = 200;
+    SIZE_UNIT_LG = 20;
 
     j = 1;
     for (i = 1; i < argc; i++)
@@ -102,6 +104,9 @@ int main(int argc, char *argv[])
             break;
           case 's':
             ARG_POSITIVE(SIZE,"Block size")
+            break;
+          case 'u':
+            ARG_POSITIVE(SIZE_UNIT_LG,"Block size unit (lg2, default=20)")
             break;
         }
       else
@@ -182,7 +187,7 @@ int main(int argc, char *argv[])
     int        nblock, ireads, treads, rlen, fno;
     int        i;
 
-    size = SIZE*1000000ll;
+    size = SIZE*(1LL << SIZE_UNIT_LG);
 
     nblock = 0;
     totlen = 0;


### PR DESCRIPTION
This lets us have multiple daligner jobs even for small test-cases.

It works perfectly for me. I can specify an exact block-size via

```
DBsplit -s50000 -u1
```

which gives me 2 50k blocks for 100k input. Or I can hit any power of 2 via

```
DBsplit -s1 -u16
```

which gives me a 64k block and a 36k block.
